### PR TITLE
Allow defining verbosity

### DIFF
--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -1,6 +1,7 @@
 module AutoSessionTimeoutHelper
   def auto_session_timeout_js(options={})
     frequency = options[:frequency] || 60
+    verbocity = options[:verbocity] || 2
     code = <<JS
 if (typeof(Ajax) != 'undefined') {
   new Ajax.PeriodicalUpdater('', '/active', {frequency:#{frequency}, method:'get', onSuccess: function(e) {
@@ -20,7 +21,7 @@ if (typeof(Ajax) != 'undefined') {
   }
   setTimeout(PeriodicalQuery, (#{frequency} * 1000));
 } else {
-  $.PeriodicalUpdater('/active', {minTimeout:#{frequency * 1000}, multiplier:0, method:'get', verbose:2}, function(remoteData, success) {
+  $.PeriodicalUpdater('/active', {minTimeout:#{frequency * 1000}, multiplier:0, method:'get', verbose:#{verbocity}}, function(remoteData, success) {
     if (success == 'success' && remoteData == 'false')
       window.location.href = '/timeout';
   });

--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -1,7 +1,7 @@
 module AutoSessionTimeoutHelper
   def auto_session_timeout_js(options={})
     frequency = options[:frequency] || 60
-    verbocity = options[:verbocity] || 2
+    verbosity = options[:verbosity] || 2
     code = <<JS
 if (typeof(Ajax) != 'undefined') {
   new Ajax.PeriodicalUpdater('', '/active', {frequency:#{frequency}, method:'get', onSuccess: function(e) {
@@ -21,7 +21,7 @@ if (typeof(Ajax) != 'undefined') {
   }
   setTimeout(PeriodicalQuery, (#{frequency} * 1000));
 } else {
-  $.PeriodicalUpdater('/active', {minTimeout:#{frequency * 1000}, multiplier:0, method:'get', verbose:#{verbocity}}, function(remoteData, success) {
+  $.PeriodicalUpdater('/active', {minTimeout:#{frequency * 1000}, multiplier:0, method:'get', verbose:#{verbosity}}, function(remoteData, success) {
     if (success == 'success' && remoteData == 'false')
       window.location.href = '/timeout';
   });


### PR DESCRIPTION
Background:
---
- This gem uses the `jquery.periodicalupdater.js` plugin.
- In `jquery.periodicalupdater.js`, `verbose` allows developer to see the error logs through the developer console of a browser.
- The values that the `verbose` attribute accepts are:
1. **0** = none
2. **1** = some 
3. **2** = all  
Reference:  
`https://github.com/RobertFischer/JQuery-PeriodicalUpdater/blob/master/jquery.periodicalupdater.js`

Changes:
---
- Instead of forcing a definite value of `verbose: 2`, it is better to change it to be definable by developers who use this gem.
- Developers may now change the value of `verbose`, to limit the logs that will be displayed in the **Developer's Console**.
- Also, these logs **should** only be displayed in a **development** environment, instead of the **production** environment, where end users may also see.