### PR TITLE
update deprecated render method

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -1,9 +1,9 @@
 module AutoSessionTimeout
-  
+
   def self.included(controller)
     controller.extend ClassMethods
   end
-  
+
   module ClassMethods
     def auto_session_timeout(seconds=nil)
       prepend_before_action do |c|
@@ -17,23 +17,23 @@ module AutoSessionTimeout
         end
       end
     end
-    
+
     def auto_session_timeout_actions
       define_method(:active) { render_session_status }
       define_method(:timeout) { render_session_timeout }
     end
   end
-  
+
   def render_session_status
     response.headers["Etag"] = ""  # clear etags to prevent caching
     render plain: !!current_user, status: 200
   end
-  
+
   def render_session_timeout
     flash[:notice] = "Your session has timed out."
-    redirect_to "/login"
+    redirect_to new_user_session_path
   end
-  
+
 end
 
 ActionController::Base.send :include, AutoSessionTimeout

--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -26,7 +26,7 @@ module AutoSessionTimeout
   
   def render_session_status
     response.headers["Etag"] = ""  # clear etags to prevent caching
-    render text: !!current_user, status: 200
+    render plain: !!current_user, status: 200
   end
   
   def render_session_timeout


### PR DESCRIPTION
Updated deprecated `render :text` call, per below deprecation warning.   

> DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/html`. 