### PR TITLE
update deprecated render method

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -26,7 +26,7 @@ module AutoSessionTimeout
   
   def render_session_status
     response.headers["Etag"] = ""  # clear etags to prevent caching
-    render text: !!current_user, status: 200
+    render plain: !!current_user, status: 200
   end
   
   def render_session_timeout


### PR DESCRIPTION
Updated deprecated render :text call, per below deprecation warning.

> DEPRECATION WARNING: render :text is deprecated because it does not actually render a text/plain response. Switch to render plain: 'plain text' to render as text/plain, render html: '<strong>HTML</strong>' to render as text/html, or render body: 'raw' to match the deprecated behavior and render with the default Content-Type, which is text/html.