### PR TITLE
Add compatibility for Rails protect_from_forgery

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -5,9 +5,9 @@ module AutoSessionTimeout
   end
   
   module ClassMethods
-    def auto_session_timeout(seconds=nil)
+    def auto_session_timeout(seconds=nil, sign_in_path)
       prepend_before_action do |c|
-        if c.session[:auto_session_expires_at] && c.session[:auto_session_expires_at] < Time.now
+        if c.session[:auto_session_expires_at] && c.session[:auto_session_expires_at] < Time.now && (sign_in_path ? !(c.env["PATH_INFO"] == sign_in_path && c.env["REQUEST_METHOD"] == "POST") : true)
           c.send :reset_session
         else
           unless c.request.original_url.start_with?(c.send(:active_url))


### PR DESCRIPTION
Make auto-session-timeout compatible with Rails' protect_from_forgery feature by adding a condition to prevent the session from being timed out if the user is logging in.  This condition is necessary because the user will receive a 'CSRF token invalid' error if they try logging in after they have been on the login page for longer than the configured timeout value (i.e. the time specified by auto_session_timeout in application_controller.rb).

If a developer wishes to take advantage of this feature, they can simply add a parameter to the auto_session_timeout declaration in application_controller.rb.  The parameter indicates the relative path of the sign in page.  For instance:  auto_session_timeout 1.hour,  '/users/sign_in'