### PR TITLE
Support Rails protect_from_forgery

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -8,7 +8,7 @@ module AutoSessionTimeout
     def auto_session_timeout(seconds=nil)
       protect_from_forgery except: [:active, :timeout]
       prepend_before_action do |c|
-        if c.session[:auto_session_expires_at] && c.session[:auto_session_expires_at] < Time.now
+        if session_expired?(c) && !signing_in?(c)
           c.send :reset_session
         else
           unless c.request.original_url.start_with?(c.send(:active_url))
@@ -31,8 +31,24 @@ module AutoSessionTimeout
   end
   
   def render_session_timeout
-    flash[:notice] = "Your session has timed out."
-    redirect_to "/login"
+    flash[:notice] = t("devise.failure.timeout", default: "Your session has timed out.")
+    redirect_to sign_in_path
+  end
+
+  private
+
+  def signing_in?(c)
+    c.request.env["PATH_INFO"] == sign_in_path && c.request.env["REQUEST_METHOD"] == "POST"
+  end
+
+  def session_expired?(c)
+    c.session[:auto_session_expires_at].try(:<, Time.now)
+  end
+
+  def sign_in_path
+    user_session_path
+  rescue
+    "/login"
   end
   
 end


### PR DESCRIPTION
Make auto-session-timeout compatible with Rails' protect_from_forgery
feature by adding a condition to prevent the session from being timed
out if the user is logging in. This condition is necessary because the
user will receive a 'CSRF token invalid' error if they try logging in
after they have been on the login page for longer than the configured
timeout value (i.e. the time specified by auto_session_timeout in
application_controller.rb).

^ description from https://github.com/pelargir/auto-session-timeout/pull/15

In addition:
* Use devise i18n entry if it exists.
* Use devise sign in path (if defined).