### PR TITLE
PeriodicalQuery - also check for null response

### DIFF
--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -9,7 +9,7 @@ function PeriodicalQuery() {
   request.onload = function (event) {
     var status = event.target.status;
     var response = event.target.response;
-    if (status === 200 && (response === false || response === 'false')) {
+    if (status === 200 && (response === false || response === 'false' || response === null)) {
       window.location.href = '/timeout';
     }
   };


### PR DESCRIPTION
The redirect was not working for me - after some logging, I noticed I was getting a null response. This fixed the issue I was encountering.