### PR TITLE
Use routes in JS helper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2019-10-15 - Use routes in JS helper [pelargir]
+
 2019-03-03 - Update README [cprodhomme]
 
 2018-12-21 - Support Rails protect_from_forgery [davegudge]

--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -10,10 +10,10 @@ function PeriodicalQuery() {
     var status = event.target.status;
     var response = event.target.response;
     if (status === 200 && (response === false || response === 'false' || response === null)) {
-      window.location.href = '/timeout';
+      window.location.href = '#{timeout_path}';
     }
   };
-  request.open('GET', '/active', true);
+  request.open('GET', '#{active_path}', true);
   request.responseType = 'json';
   request.send();
   setTimeout(PeriodicalQuery, (#{frequency} * 1000));

--- a/test/auto_session_timeout_helper_test.rb
+++ b/test/auto_session_timeout_helper_test.rb
@@ -2,6 +2,16 @@ require File.dirname(__FILE__) + '/test_helper'
 
 describe AutoSessionTimeoutHelper do
 
+  class ActionView::Base
+    def timeout_path
+      '/timeout'
+    end
+    
+    def active_path
+      '/active'
+    end
+  end
+
   subject { ActionView::Base.new }
 
   describe "#auto_session_timeout_js" do


### PR DESCRIPTION
Instead of hard coding the active and timeout action paths, use the named routes. This ensures the paths will be correct when the routes are defined inside prefixed scopes in the routes file.

This fixes issue #24.