### PR TITLE
Enable gem to be installed with Rails 6

### DIFF
--- a/auto-session-timeout.gemspec
+++ b/auto-session-timeout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", [">= 3.2", "< 6.0"]
+  spec.add_dependency "actionpack", [">= 3.2"]
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", [">= 4.2", "< 6"]


### PR DESCRIPTION
Hi,

It seems like the vulnerabilities for actionpack are patched with versions >= 6.0.3.4 (https://snyk.io/vuln/rubygems:actionpack)

This PR allows this gem to use actionpack versions >= 6.0.3.4 as a dependency.