### PR TITLE
Compatablity issue with Rack 2.2.4

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -26,7 +26,7 @@ module AutoSessionTimeout
   end
   
   def render_session_status
-    response.headers["Etag"] = ""  # clear etags to prevent caching
+    response.headers["Etag"] = nil  # clear etags to prevent caching
     render plain: !!current_user, status: 200
   end
   


### PR DESCRIPTION
Hey,

I found an issue when upgrading to rack 2.2.4

For me it was only an issue on localhost ( Fine on production ) the logs would show a 200 status but the browser would view it as a 302 status. 

![image](https://user-images.githubusercontent.com/7695715/219694875-eac5e51f-6025-4c6a-b886-f7fb316f0dcd.png)

![image](https://user-images.githubusercontent.com/7695715/219695004-b2a44568-0009-47b2-8abf-addc5d1c8f4b.png)


I believe it is to do with this change in the rack gem. The Etag "" now gets read as an existing Etag rather removing it.
https://github.com/rack/rack/pull/1919/files

In the PR I just set the Etag to nil instead of "" and it seems to work.

![image](https://user-images.githubusercontent.com/7695715/219693858-85108f0c-831d-4ff9-b7c2-8f84f00a186b.png)