### PR TITLE
Added before_session_reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ seconds. The following example checks the server every 15 seconds:
 </body>
 ```
 
+## Perform operation before session reset
+
+If you want to perform some operation before session reset, you can use `before_session_reset` method. This method takes a block which will be executed before session reset. For example, perform some app specific operation, you can do it like this:
+
+Create a controller concern called `before_session_reset.rb` and add following code to it:
+
+```rb
+module BeforeSessionReset
+ extend ActiveSupport::Concern
+
+ private
+
+   def before_session_reset
+     # your custom code goes here
+   end
+end
+```
+
+After that, include this concern in your `ApplicationController` along with `auto_session_timeout`:
+
+```rb
+include BeforeSessionReset
+auto_session_timeout
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -1,12 +1,11 @@
 module AutoSessionTimeout
-  
   def self.included(controller)
     controller.extend ClassMethods
   end
-  
+
   module ClassMethods
-    def auto_session_timeout(seconds=nil)
-      protect_from_forgery except: [:active, :timeout]
+    def auto_session_timeout(seconds = nil)
+      protect_from_forgery except: %i[active timeout]
       prepend_before_action do |c|
         if session_expired?(c) && !signing_in?(c)
           handle_session_reset(c)
@@ -18,31 +17,32 @@ module AutoSessionTimeout
         end
       end
     end
-    
+
     def auto_session_timeout_actions
       define_method(:active) { render_session_status }
       define_method(:timeout) { render_session_timeout }
     end
   end
-  
+
   def render_session_status
-    response.headers["Etag"] = nil  # clear etags to prevent caching
+    response.headers['Etag'] = nil  # clear etags to prevent caching
     render plain: !!current_user, status: 200
   end
-  
+
   def render_session_timeout
-    flash[:notice] = t("devise.failure.timeout", default: "Your session has timed out.")
+    flash[:notice] = t('devise.failure.timeout', default: 'Your session has timed out.')
     redirect_to sign_in_path
   end
 
   private
 
   def handle_session_reset(c)
+    before_session_reset if respond_to?(:before_session_reset)
     c.send :reset_session
   end
 
   def signing_in?(c)
-    c.request.env["PATH_INFO"] == sign_in_path && c.request.env["REQUEST_METHOD"] == "POST"
+    c.request.env['PATH_INFO'] == sign_in_path && c.request.env['REQUEST_METHOD'] == 'POST'
   end
 
   def session_expired?(c)
@@ -51,10 +51,9 @@ module AutoSessionTimeout
 
   def sign_in_path
     user_session_path
-  rescue
-    "/login"
+  rescue StandardError
+    '/login'
   end
-  
 end
 
-ActionController::Base.send :include, AutoSessionTimeout
+ActionController::Base.include AutoSessionTimeout

--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -1,11 +1,12 @@
 module AutoSessionTimeout
+  
   def self.included(controller)
     controller.extend ClassMethods
   end
-
+  
   module ClassMethods
-    def auto_session_timeout(seconds = nil)
-      protect_from_forgery except: %i[active timeout]
+    def auto_session_timeout(seconds=nil)
+      protect_from_forgery except: [:active, :timeout]
       prepend_before_action do |c|
         if session_expired?(c) && !signing_in?(c)
           handle_session_reset(c)
@@ -17,20 +18,20 @@ module AutoSessionTimeout
         end
       end
     end
-
+    
     def auto_session_timeout_actions
       define_method(:active) { render_session_status }
       define_method(:timeout) { render_session_timeout }
     end
   end
-
+  
   def render_session_status
-    response.headers['Etag'] = nil  # clear etags to prevent caching
+    response.headers["Etag"] = nil  # clear etags to prevent caching
     render plain: !!current_user, status: 200
   end
-
+  
   def render_session_timeout
-    flash[:notice] = t('devise.failure.timeout', default: 'Your session has timed out.')
+    flash[:notice] = t("devise.failure.timeout", default: "Your session has timed out.")
     redirect_to sign_in_path
   end
 
@@ -42,7 +43,7 @@ module AutoSessionTimeout
   end
 
   def signing_in?(c)
-    c.request.env['PATH_INFO'] == sign_in_path && c.request.env['REQUEST_METHOD'] == 'POST'
+    c.request.env["PATH_INFO"] == sign_in_path && c.request.env["REQUEST_METHOD"] == "POST"
   end
 
   def session_expired?(c)
@@ -51,9 +52,10 @@ module AutoSessionTimeout
 
   def sign_in_path
     user_session_path
-  rescue StandardError
-    '/login'
+  rescue
+    "/login"
   end
+  
 end
 
-ActionController::Base.include AutoSessionTimeout
+ActionController::Base.send :include, AutoSessionTimeout


### PR DESCRIPTION
Added `before_session_reset`.

User can provide a concern named `before_session_reset` to do some custom operation before the session is reset by the gem.