### PR TITLE
Add checks for compatibility with Rails v7.1

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -12,37 +12,73 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0']
+        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0.1', '7.1']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         exclude:
           - rails-version: '3.2'
             ruby-version: '2.7'
           - rails-version: '3.2'
             ruby-version: '3.0'
+          - rails-version: '3.2'
+            ruby-version: '3.1'
+          - rails-version: '3.2'
+            ruby-version: '3.2'
 
           - rails-version: '4.0'
             ruby-version: '2.7'
           - rails-version: '4.0'
             ruby-version: '3.0'
+          - rails-version: '4.0'
+            ruby-version: '3.1'
+          - rails-version: '4.0'
+            ruby-version: '3.2'
 
           - rails-version: '4.1'
             ruby-version: '2.7'
           - rails-version: '4.1'
             ruby-version: '3.0'
+          - rails-version: '4.1'
+            ruby-version: '3.1'
+          - rails-version: '4.1'
+            ruby-version: '3.2'
 
+          - rails-version: '4.2'
+            ruby-version: '2.4'
           - rails-version: '4.2'
             ruby-version: '2.7'
           - rails-version: '4.2'
             ruby-version: '3.0'
+          - rails-version: '4.2'
+            ruby-version: '3.1'
+          - rails-version: '4.2'
+            ruby-version: '3.2'
 
           - rails-version: '5.0'
+            ruby-version: '2.4'
+          - rails-version: '5.0'
             ruby-version: '3.0'
+          - rails-version: '5.0'
+            ruby-version: '3.1'
+          - rails-version: '5.0'
+            ruby-version: '3.2'
 
           - rails-version: '5.1'
+            ruby-version: '2.4'
+          - rails-version: '5.1'
             ruby-version: '3.0'
+          - rails-version: '5.1'
+            ruby-version: '3.1'
+          - rails-version: '5.1'
+            ruby-version: '3.2'
 
           - rails-version: '5.2'
+            ruby-version: '2.4'
+          - rails-version: '5.2'
             ruby-version: '3.0'
+          - rails-version: '5.2'
+            ruby-version: '3.1'
+          - rails-version: '5.2'
+            ruby-version: '3.2'
 
           - rails-version: '6.0'
             ruby-version: '2.4'
@@ -50,11 +86,18 @@ jobs:
           - rails-version: '6.1'
             ruby-version: '2.4'
 
-          - rails-version: '7.0'
+          - rails-version: '7.0.1'
             ruby-version: '2.4'
-          - rails-version: '7.0'
+          - rails-version: '7.0.1'
             ruby-version: '2.5'
-          - rails-version: '7.0'
+          - rails-version: '7.0.1'
+            ruby-version: '2.6'
+
+          - rails-version: '7.1'
+            ruby-version: '2.4'
+          - rails-version: '7.1'
+            ruby-version: '2.5'
+          - rails-version: '7.1'
             ruby-version: '2.6'
     steps:
     - uses: actions/checkout@v2

--- a/auto-session-timeout.gemspec
+++ b/auto-session-timeout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", [">= 3.2", "< 7.1"]
+  spec.add_dependency "actionpack", [">= 3.2", "< 7.2"]
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", [">= 4.2", "< 6"]


### PR DESCRIPTION
Add checks for compatibility with Rails v7.1 and Ruby > v3.0.

I found that some versions of Rails did not seem to work with Ruby v2.4 so I excluded them from the matrix. There is also an issue with Rails 7.0 and Ruby > v3.0 so I changed the Rails version it is tested against to 7.0.1 (which is the first version that fixed the issue).