### PR TITLE
chore: update compatibility with rails 7.2

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0.1', '7.1']
+        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0.1', '7.1', '7.2']
         ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         exclude:
           - rails-version: '3.2'
@@ -99,6 +99,17 @@ jobs:
             ruby-version: '2.5'
           - rails-version: '7.1'
             ruby-version: '2.6'
+
+          - rails-version: '7.2'
+            ruby-version: '2.4'
+          - rails-version: '7.2'
+            ruby-version: '2.5'
+          - rails-version: '7.2'
+            ruby-version: '2.6'
+          - rails-version: '7.2'
+            ruby-version: '2.7'
+          - rails-version: '7.2'
+            ruby-version: '3.0'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/auto-session-timeout.gemspec
+++ b/auto-session-timeout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", [">= 3.2", "< 7.2"]
+  spec.add_dependency "actionpack", [">= 3.2", "< 7.3"]
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", [">= 4.2", "< 6"]

--- a/lib/auto/session/timeout/version.rb
+++ b/lib/auto/session/timeout/version.rb
@@ -1,7 +1,7 @@
 module Auto
   module Session
     module Timeout
-      VERSION = "1.1"
+      VERSION = "1.2"
     end
   end
 end


### PR DESCRIPTION
This PR brings compatibility with the recently released Rails 7.2 version.