### PR TITLE
Allow Rails 8.0

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0.1', '7.1', '7.2']
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        rails-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0.1', '7.1', '7.2', '8.0']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         exclude:
           - rails-version: '3.2'
             ruby-version: '2.7'
@@ -23,6 +23,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '3.2'
             ruby-version: '3.2'
+          - rails-version: '3.2'
+            ruby-version: '3.3'
 
           - rails-version: '4.0'
             ruby-version: '2.7'
@@ -32,6 +34,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '4.0'
             ruby-version: '3.2'
+          - rails-version: '4.0'
+            ruby-version: '3.3'
 
           - rails-version: '4.1'
             ruby-version: '2.7'
@@ -41,6 +45,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '4.1'
             ruby-version: '3.2'
+          - rails-version: '4.1'
+            ruby-version: '3.3'
 
           - rails-version: '4.2'
             ruby-version: '2.4'
@@ -52,6 +58,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '4.2'
             ruby-version: '3.2'
+          - rails-version: '4.2'
+            ruby-version: '3.3'
 
           - rails-version: '5.0'
             ruby-version: '2.4'
@@ -61,6 +69,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '5.0'
             ruby-version: '3.2'
+          - rails-version: '5.0'
+            ruby-version: '3.3'
 
           - rails-version: '5.1'
             ruby-version: '2.4'
@@ -70,6 +80,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '5.1'
             ruby-version: '3.2'
+          - rails-version: '5.1'
+            ruby-version: '3.3'
 
           - rails-version: '5.2'
             ruby-version: '2.4'
@@ -79,6 +91,8 @@ jobs:
             ruby-version: '3.1'
           - rails-version: '5.2'
             ruby-version: '3.2'
+          - rails-version: '5.2'
+            ruby-version: '3.3'
 
           - rails-version: '6.0'
             ruby-version: '2.4'
@@ -110,6 +124,19 @@ jobs:
             ruby-version: '2.7'
           - rails-version: '7.2'
             ruby-version: '3.0'
+
+          - rails-version: '8.0'
+            ruby-version: '2.4'
+          - rails-version: '8.0'
+            ruby-version: '2.5'
+          - rails-version: '8.0'
+            ruby-version: '2.6'
+          - rails-version: '8.0'
+            ruby-version: '2.7'
+          - rails-version: '8.0'
+            ruby-version: '3.0'
+          - rails-version: '8.0'
+            ruby-version: '3.1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/auto-session-timeout.gemspec
+++ b/auto-session-timeout.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", [">= 3.2", "< 7.3"]
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_dependency "actionpack", [">= 3.2", "< 8.1"]
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", [">= 4.2", "< 6"]
 end


### PR DESCRIPTION
Adds Rails 8.0 and Ruby 3.3 to minitest.yml
Allows actionpack 8.0 in gemspec