### PR TITLE
Use ActiveSupport.on_load for lazy module inclusion

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -56,4 +56,6 @@ module AutoSessionTimeout
 
 end
 
-ActionController::Base.send :include, AutoSessionTimeout
+ActiveSupport.on_load(:action_controller) do
+  include AutoSessionTimeout
+end

--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -24,4 +24,6 @@ JS
   end
 end
 
-ActionView::Base.send :include, AutoSessionTimeoutHelper
+ActiveSupport.on_load(:action_view) do
+  include AutoSessionTimeoutHelper
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,5 +2,6 @@ require 'rubygems'
 require 'minitest/autorun'
 require 'logger'
 require 'action_controller'
+require 'action_view'
 
 require File.expand_path(File.dirname(__FILE__) + '/../lib/auto-session-timeout')


### PR DESCRIPTION
## Summary

- Switch from eager loading modules into `ActionController::Base` and `ActionView::Base` to using `ActiveSupport.on_load` hooks
- This is the recommended approach for Rails 3.0+ and avoids deprecation warnings in Rails 6+ when referencing base classes before they're fully initialized

## Changes

```ruby
# Before:
ActionController::Base.send :include, AutoSessionTimeout
ActionView::Base.send :include, AutoSessionTimeoutHelper

# After:
ActiveSupport.on_load(:action_controller) do
  include AutoSessionTimeout
end

ActiveSupport.on_load(:action_view) do
  include AutoSessionTimeoutHelper
end
```

Fixes #27

## Test plan

- [x] All existing tests pass
- [x] Added `require 'action_view'` to test helper for proper test coverage