### PR TITLE
Fix duplicate polling with Turbolinks/Turbo

### DIFF
--- a/lib/auto_session_timeout_helper.rb
+++ b/lib/auto_session_timeout_helper.rb
@@ -4,6 +4,9 @@ module AutoSessionTimeoutHelper
     attributes = options[:attributes] || {}
     timeout_url = options[:timeout_path] || timeout_path
     code = <<JS
+if (typeof(window.autoSessionTimeoutId) !== 'undefined') {
+  clearTimeout(window.autoSessionTimeoutId);
+}
 function PeriodicalQuery() {
   var request = new XMLHttpRequest();
   request.onload = function (event) {
@@ -16,9 +19,9 @@ function PeriodicalQuery() {
   request.open('GET', '#{active_path}', true);
   request.responseType = 'json';
   request.send();
-  setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+  window.autoSessionTimeoutId = setTimeout(PeriodicalQuery, (#{frequency} * 1000));
 }
-setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+window.autoSessionTimeoutId = setTimeout(PeriodicalQuery, (#{frequency} * 1000));
 JS
     javascript_tag(code, attributes)
   end

--- a/test/auto_session_timeout_helper_test.rb
+++ b/test/auto_session_timeout_helper_test.rb
@@ -53,6 +53,12 @@ describe AutoSessionTimeoutHelper do
       js = subject.auto_session_timeout_js(timeout_path: '/timeout?login_source=web&customer=123&location=home')
       assert js.include?("window.location.href = '/timeout?login_source=web&customer=123&location=home'")
     end
+
+    it "clears existing timeout to prevent duplicates with Turbolinks/Turbo" do
+      js = subject.auto_session_timeout_js
+      assert js.include?("clearTimeout(window.autoSessionTimeoutId)")
+      assert js.include?("window.autoSessionTimeoutId = setTimeout(PeriodicalQuery")
+    end
   end
 
 end


### PR DESCRIPTION
## Summary

- Fix duplicate `/active` polling requests when using Turbolinks or Turbo
- Store the timeout ID globally in `window.autoSessionTimeoutId`
- Clear any existing timeout before starting a new one on page navigation

## Problem

With Turbolinks/Turbo, each page navigation re-executes the JavaScript without clearing the previous `setTimeout`. This causes multiple polling chains to stack up, resulting in increasingly frequent requests to `/active`:

```
Started GET "/active" for 127.0.0.1 at 2019-01-21 13:28:48 +0000
Started GET "/active" for 127.0.0.1 at 2019-01-21 13:29:16 +0000
Started GET "/active" for 127.0.0.1 at 2019-01-21 13:29:37 +0000
...
```

## Solution

```javascript
// Clear any existing timeout before starting a new one
if (typeof(window.autoSessionTimeoutId) !== 'undefined') {
  clearTimeout(window.autoSessionTimeoutId);
}

// Store timeout ID globally so it can be cleared on next page load
window.autoSessionTimeoutId = setTimeout(PeriodicalQuery, (frequency * 1000));
```

Fixes #16

## Test plan

- [x] Added test verifying `clearTimeout` and global timeout ID storage
- [x] All existing tests pass