### PR TITLE
Fix route helper lookup when using mounted engines

### DIFF
--- a/lib/auto_session_timeout.rb
+++ b/lib/auto_session_timeout.rb
@@ -54,6 +54,12 @@ module AutoSessionTimeout
     "/login"
   end
 
+  def active_url
+    main_app.active_url
+  rescue
+    "/active"
+  end
+
 end
 
 ActiveSupport.on_load(:action_controller) do

--- a/test/auto_session_timeout_test.rb
+++ b/test/auto_session_timeout_test.rb
@@ -2,8 +2,58 @@ require File.dirname(__FILE__) + '/test_helper'
 
 describe AutoSessionTimeout do
 
-  it "tests something" do
-    assert true
+  class MainApp
+    def active_url
+      "http://example.com/active"
+    end
+  end
+
+  class StubController
+    include AutoSessionTimeout
+
+    def main_app
+      MainApp.new
+    end
+
+    def user_session_path
+      "/users/sign_in"
+    end
+  end
+
+  class StubControllerWithoutRoutes
+    include AutoSessionTimeout
+
+    def main_app
+      raise NoMethodError, "undefined method `active_url'"
+    end
+
+    def user_session_path
+      raise NoMethodError, "undefined method `user_session_path'"
+    end
+  end
+
+  describe "#active_url" do
+    it "returns main_app.active_url when available" do
+      controller = StubController.new
+      assert_equal "http://example.com/active", controller.send(:active_url)
+    end
+
+    it "falls back to /active when main_app.active_url is not available" do
+      controller = StubControllerWithoutRoutes.new
+      assert_equal "/active", controller.send(:active_url)
+    end
+  end
+
+  describe "#sign_in_path" do
+    it "returns user_session_path when available" do
+      controller = StubController.new
+      assert_equal "/users/sign_in", controller.send(:sign_in_path)
+    end
+
+    it "falls back to /login when user_session_path is not available" do
+      controller = StubControllerWithoutRoutes.new
+      assert_equal "/login", controller.send(:sign_in_path)
+    end
   end
 
 end


### PR DESCRIPTION
## Summary

- Add `active_url` method that uses `main_app.active_url` to explicitly access the main application's route helpers
- Falls back to `"/active"` if the route helper is not available
- Fixes "No route matches" errors when using the gem with mounted engines like Solidus/Spree

## Problem

When using the gem inside a mounted engine (e.g., Solidus/Spree), the route helper lookup is scoped to the engine's namespace:

```
ActionController::UrlGenerationError in Spree::OrdersController#edit
No route matches {:action=>"active", :controller=>"sessions"}
```

Users had to work around this by manually defining `active_url` in their ApplicationController.

## Solution

Similar to how `sign_in_path` handles Devise route helpers with a fallback, the new `active_url` method:

1. First tries `main_app.active_url` to explicitly get the main app's route
2. Falls back to `"/active"` if that fails

```ruby
def active_url
  main_app.active_url
rescue
  "/active"
end
```

Fixes #32

## Test plan

- [x] All existing tests pass
- [x] Pattern matches existing `sign_in_path` implementation